### PR TITLE
fix: install python2 and pyserial

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:bullseye-slim
 
 RUN apt-get update && apt-get install -y \
   make \
+  python2 \
   python3 \
   wget \
   tar \
@@ -10,9 +11,13 @@ RUN apt-get update && apt-get install -y \
   bzip2 \
 && rm -rf /var/lib/apt/lists/*
 
+RUN wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
+  python2 get-pip.py && \
+  python2 -m pip install pyserial
+
 WORKDIR /opt
 
-RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN ln -s /usr/bin/python2 /usr/bin/python
 
 #RUN pip --no-cache-dir install pyserial
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OBJ_NO_DIR = $(CSRC:%.c=%.o)
 OBJ = $(patsubst %.c,$(BIN_PATH)/%.o,$(CSRC))
 
 DOCKER_IMAGE_NAME = mighty-arm-development
-DOCKER_TAG = 2023_11
+DOCKER_TAG = 2024_03
 DOCKER_IMAGE_NAME_WITH_TAG = $(DOCKER_IMAGE_NAME):$(DOCKER_TAG)
 
 PORT = /dev/ttyUSB0


### PR DESCRIPTION
Python2 is needed to use the stm32loader.py script